### PR TITLE
Add functioning subword motions

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,16 +424,23 @@ Update your keymap.json file with the following key bindings:
       "S": ["vim::PushSneakBackward", {}],
     },
   },
-  // Subword motion is not working really nice with `ciw`, disable for now
-  // {
-  //   "context": "VimControl && !menu",
-  //   "bindings": {
-  //     "w": "vim::NextSubwordStart",
-  //     "b": "vim::PreviousSubwordStart",
-  //     "e": "vim::NextSubwordEnd",
-  //     "g e": "vim::PreviousSubwordEnd"
-  //   }
-  // }
+{
+    "context": "VimControl && !menu",
+    "bindings": {
+      "space w": "vim::NextSubwordStart",
+      "space b": "vim::PreviousSubwordStart",
+      "space e": "vim::NextSubwordEnd",
+      "g e": "vim::PreviousSubwordEnd"
+    }  
+  },
+  // subword motion with space as leader key
+  // fixes "[operator]i w" -> operates on subword
+  {
+    "context": "vim_mode == operator && vim_operator == i",
+    "bindings": {
+      "space w": "vim::Subword"
+    }
+  }
 ]
 ```
 

--- a/keymap.json
+++ b/keymap.json
@@ -202,15 +202,23 @@
       "s": ["vim::PushSneak", {}],
       "S": ["vim::PushSneakBackward", {}]
     }
-  }
-  // Subword motion is not working really nice with `ciw`, disable for now
-  // {
-  //   "context": "VimControl && !menu",
-  //   "bindings": {
-  //     "w": "vim::NextSubwordStart",
-  //     "b": "vim::PreviousSubwordStart",
-  //     "e": "vim::NextSubwordEnd",
-  //     "g e": "vim::PreviousSubwordEnd"
-  //   }
-  // }
+  },
+  // subword motion with space as leader key
+  {
+    "context": "VimControl && !menu",
+    "bindings": {
+      "space w": "vim::NextSubwordStart",
+      "space b": "vim::PreviousSubwordStart",
+      "space e": "vim::NextSubwordEnd",
+      "g e": "vim::PreviousSubwordEnd"
+    }  
+  },
+  // subword motion with space as leader key
+  // fixes "[operator]i w" -> operates on subword
+  {
+    "context": "vim_mode == operator && vim_operator == i",
+    "bindings": {
+      "space w": "vim::Subword"
+    }
+  },
 ]

--- a/keymap.json
+++ b/keymap.json
@@ -220,5 +220,5 @@
     "bindings": {
       "space w": "vim::Subword"
     }
-  },
+  }
 ]


### PR DESCRIPTION
## WHAT

added the subword motions with space as a leader key with `[operator]i w` functionality

## WHY

i like subword motions and figured out how to use `ci w` in zed

## HOW
if you have `"context": "vim_mode == operator && vim_operator == i"`, then you overwrite the subword motion from before (`vim::NextSubwordStart`) with the `vim::Subword` command
```js
"bindings": {
      "space w": "vim::Subword"
    }
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] Linter
- [ ] Tests
- [ ] Review comments
- [ ] Security

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds subword motions with space as a leader key in Vim mode, supporting `[operator]i w` functionality.
> 
>   - **Behavior**:
>     - Adds subword motions with space as a leader key in `keymap.json`.
>     - Supports `[operator]i w` functionality to operate on subwords.
>   - **Key Bindings**:
>     - Adds `space w`, `space b`, `space e`, and `g e` for subword navigation in `keymap.json`.
>     - Adds `space w` for subword operation in operator mode in `keymap.json`.
>   - **Documentation**:
>     - Updates `README.md` to reflect new subword motion key bindings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jellydn%2Fzed-101-setup&utm_source=github&utm_medium=referral)<sup> for a93afdd65a6fdb6729869a4a5b2ae5aa22b5363d. You can [customize](https://app.ellipsis.dev/jellydn/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keybindings for subword navigation: space-w, space-b, space-e, and g e now enable quick movement between subword boundaries.
  * Re-enabled subword motion support in operator-pending mode for more intuitive text manipulation.

* **Documentation**
  * Updated configuration documentation reflecting new keybinding options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->