### PR TITLE
feat: add FFF GUI keybindings and cleanup Zed config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Update your settings.json file with the following configuration:
 <!-- ALL-SETTINGS:START -->
 
 ```jsonc
-// settings.json, generated at Fri May 22 2026 06:36:22 GMT+0800 (Singapore Standard Time)
+// settings.json, generated at Wed May 27 2026 12:34:47 GMT+0800 (Singapore Standard Time)
 // Zed settings
 //
 // For information on how to configure Zed, see the Zed
@@ -437,7 +437,7 @@ Update your keymap.json file with the following key bindings:
 <!-- ALL-KEYMAPS:START -->
 
 ```jsonc
-// keymap.json, generated at Fri May 22 2026 06:36:22 GMT+0800 (Singapore Standard Time)
+// keymap.json, generated at Wed May 27 2026 12:34:47 GMT+0800 (Singapore Standard Time)
 [
   {
     "context": "Editor && (vim_mode == normal || vim_mode == visual) && !VimWaiting && !menu",
@@ -677,12 +677,11 @@ Update your tasks.json file with the following task definitions:
 <!-- ALL-TASKS:START -->
 
 ```jsonc
-// tasks.json, generated at Fri May 22 2026 06:36:22 GMT+0800 (Singapore Standard Time)
+// tasks.json, generated at Wed May 27 2026 12:34:47 GMT+0800 (Singapore Standard Time)
 [
   {
     "label": "fff-gpui: Files",
-    "command": "fff-gpui --open .",
-    "env": { "EDITOR": "zed" },
+    "command": "EDITOR=zed fff-gpui --open .",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
     "reveal": "never",
@@ -695,8 +694,7 @@ Update your tasks.json file with the following task definitions:
   },
   {
     "label": "fff-gpui: Grep",
-    "command": "fff-gpui --open . --grep",
-    "env": { "EDITOR": "zed" },
+    "command": "EDITOR=zed fff-gpui --open . --grep",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
     "reveal": "never",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Update your settings.json file with the following configuration:
 <!-- ALL-SETTINGS:START -->
 
 ```jsonc
-// settings.json, generated at Thu May 21 2026 12:59:21 GMT+0800 (Singapore Standard Time)
+// settings.json, generated at Fri May 22 2026 06:36:22 GMT+0800 (Singapore Standard Time)
 // Zed settings
 //
 // For information on how to configure Zed, see the Zed
@@ -437,7 +437,7 @@ Update your keymap.json file with the following key bindings:
 <!-- ALL-KEYMAPS:START -->
 
 ```jsonc
-// keymap.json, generated at Thu May 21 2026 12:59:21 GMT+0800 (Singapore Standard Time)
+// keymap.json, generated at Fri May 22 2026 06:36:22 GMT+0800 (Singapore Standard Time)
 [
   {
     "context": "Editor && (vim_mode == normal || vim_mode == visual) && !VimWaiting && !menu",
@@ -669,6 +669,55 @@ Update your keymap.json file with the following key bindings:
 ```
 
 <!-- ALL-KEYMAPS:END -->
+
+## Tasks
+
+Update your tasks.json file with the following task definitions:
+
+<!-- ALL-TASKS:START -->
+
+```jsonc
+// tasks.json, generated at Fri May 22 2026 06:36:22 GMT+0800 (Singapore Standard Time)
+[
+  {
+    "label": "fff-gpui: Files",
+    "command": "fff-gpui --open .",
+    "env": { "EDITOR": "zed" },
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "never",
+    "reveal_target": "dock",
+    "hide": "always",
+    "shell": "system",
+    "show_summary": false,
+    "show_command": false,
+    "save": "none",
+  },
+  {
+    "label": "fff-gpui: Grep",
+    "command": "fff-gpui --open . --grep",
+    "env": { "EDITOR": "zed" },
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "never",
+    "reveal_target": "dock",
+    "hide": "always",
+    "shell": "system",
+    "show_summary": false,
+    "show_command": false,
+    "save": "none",
+  },
+]
+```
+
+<!-- ALL-TASKS:END -->
+
+### Task Markers for FFF GUI
+
+The tasks above enable the `space f f` and `space f g` keybindings defined in Keymaps. They spawn `fff-gpui` with the current directory as root.
+
+- `fff-gpui: Files` — Opens an interactive file picker using [fff-gpui](https://github.com/th0jensen/fff-gpui)
+- `fff-gpui: Grep` — Opens an interactive grep search across project files
 
 ## Setup local AI with Ollama
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,41 @@ curl -fsSL https://raw.githubusercontent.com/getnf/getnf/main/install.sh | bash
 getnf
 ```
 
+## zed-codemux
+
+This setup uses [zed-codemux](https://github.com/jellydn/zed-codemux) as the default terminal shell, providing a multiplexer experience within Zed Editor. Install via:
+
+```sh
+cargo install zed-codemux
+```
+
+Then configure in `settings.json`:
+
+```jsonc
+"terminal": {
+  "shell": {
+    "program": "/path/to/codemux"
+  }
+}
+```
+
+## FFF GUI
+
+This setup integrates [fff-gpui](https://github.com/th0jensen/fff-gpui), a native-GUI fuzzy file finder and grep tool for Zed. It provides quick file navigation and project-wide search with a minimal TUI interface.
+
+Install via:
+
+```sh
+brew install fff-gpui
+```
+
+Keybindings:
+
+| Keybinding  | Action                       |
+| ----------- | ---------------------------- |
+| `space f f` | Open interactive file picker |
+| `space f g` | Open interactive grep search |
+
 ## Vim mode
 
 For detailed Vim mode setup instructions, refer to the [Zed Vim Mode Documentation](https://zed.dev/docs/vim).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Update your settings.json file with the following configuration:
 <!-- ALL-SETTINGS:START -->
 
 ```jsonc
-// settings.json, generated at Wed May 06 2026 07:46:59 GMT+0800 (Singapore Standard Time)
+// settings.json, generated at Thu May 21 2026 12:59:21 GMT+0800 (Singapore Standard Time)
 // Zed settings
 //
 // For information on how to configure Zed, see the Zed
@@ -116,7 +116,6 @@ Update your settings.json file with the following configuration:
   "use_system_window_tabs": true,
   "buffer_font_fallbacks": [
     "Maple Mono NF",
-    "OperatorMonoLig Nerd Font",
     "JetBrainsMono Nerd Font Mono",
     "Menlo",
     "Monaco",
@@ -415,10 +414,6 @@ Update your settings.json file with the following configuration:
   "collaboration_panel": {
     "dock": "right",
   },
-  // Move some unnecessary panels to the left
-  "notification_panel": {
-    "dock": "left",
-  },
   "context_servers": {
     "react-grab-mcp": {
       "command": "npx",
@@ -442,7 +437,7 @@ Update your keymap.json file with the following key bindings:
 <!-- ALL-KEYMAPS:START -->
 
 ```jsonc
-// keymap.json, generated at Wed May 06 2026 07:46:59 GMT+0800 (Singapore Standard Time)
+// keymap.json, generated at Thu May 21 2026 12:59:21 GMT+0800 (Singapore Standard Time)
 [
   {
     "context": "Editor && (vim_mode == normal || vim_mode == visual) && !VimWaiting && !menu",
@@ -650,6 +645,14 @@ Update your keymap.json file with the following key bindings:
     "context": "(VimControl && !menu)",
     "bindings": {
       "space": null, // Disable the default action vim::WrappingRight
+    },
+  },
+  // FFF GUI, refer https://github.com/th0jensen/fff-gpui#configuration
+  {
+    "context": "Workspace",
+    "bindings": {
+      "space f f": ["task::Spawn", { "task_name": "fff-gpui: Files" }],
+      "space f g": ["task::Spawn", { "task_name": "fff-gpui: Grep" }],
     },
   },
   // Subword motion is not working really nice with `ciw`, disable for now

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ This setup integrates [fff-gpui](https://github.com/th0jensen/fff-gpui), a nativ
 Install via:
 
 ```sh
+brew tap th0jensen/fff-gpui
 brew install fff-gpui
+brew services start fff-gpui
 ```
 
 Keybindings:

--- a/cli.sh
+++ b/cli.sh
@@ -8,6 +8,10 @@ cp ~/.config/zed/settings.json settings.json
 echo "Copying keymap.json..."
 cp ~/.config/zed/keymap.json keymap.json
 
+# Copy tasks.json
+echo "Copying tasks.json..."
+cp ~/.config/zed/tasks.json tasks.json
+
 # Run cli.ts
 echo "Running cli.ts..."
 bun run cli.ts

--- a/cli.sh
+++ b/cli.sh
@@ -8,9 +8,11 @@ cp ~/.config/zed/settings.json settings.json
 echo "Copying keymap.json..."
 cp ~/.config/zed/keymap.json keymap.json
 
-# Copy tasks.json
-echo "Copying tasks.json..."
-cp ~/.config/zed/tasks.json tasks.json
+# Copy tasks.json if it exists
+if [ -f ~/.config/zed/tasks.json ]; then
+	echo "Copying tasks.json..."
+	cp ~/.config/zed/tasks.json tasks.json
+fi
 
 # Run cli.ts
 echo "Running cli.ts..."

--- a/cli.ts
+++ b/cli.ts
@@ -11,6 +11,7 @@ const __dirname = path.dirname(__filename);
  * ```bash
  * cp ~/.config/zed/keymap.json keymap.json
  * cp ~/.config/zed/settings.json settings.json
+ * cp ~/.config/zed/tasks.json tasks.json
  * ```
  */
 
@@ -33,10 +34,12 @@ ${data}
 try {
 	const settings = readFileSync(path.join(__dirname, "settings.json"));
 	const keymap = readFileSync(path.join(__dirname, "keymap.json"));
+	const tasks = readFileSync(path.join(__dirname, "tasks.json"));
 	const data = readFileSync(filePath);
 
 	const settingsMarkdown = generateMarkdown("settings.json", settings);
 	const keymapsMarkdown = generateMarkdown("keymap.json", keymap);
+	const tasksMarkdown = generateMarkdown("tasks.json", tasks);
 
 	let result = data.replace(
 		/(<!-- ALL-SETTINGS:START -->)[\s\S]*?(<!-- ALL-SETTINGS:END -->)/gs,
@@ -45,6 +48,10 @@ try {
 	result = result.replace(
 		/(<!-- ALL-KEYMAPS:START -->)[\s\S]*?(<!-- ALL-KEYMAPS:END -->)/gs,
 		`$1\n${keymapsMarkdown}\n$2`,
+	);
+	result = result.replace(
+		/(<!-- ALL-TASKS:START -->)[\s\S]*?(<!-- ALL-TASKS:END -->)/gs,
+		`$1\n${tasksMarkdown}\n$2`,
 	);
 
 	fs.writeFileSync(filePath, result);

--- a/keymap.json
+++ b/keymap.json
@@ -32,7 +32,7 @@
 		"bindings": {
 			// put key-bindings here if you want them to work only in normal mode
 			// Window movement bindings
-			// Ctrl jklk to move between panes
+			// Ctrl hjkl to move between panes
 			"ctrl-h": "workspace::ActivatePaneLeft",
 			"ctrl-l": "workspace::ActivatePaneRight",
 			"ctrl-k": "workspace::ActivatePaneUp",
@@ -163,7 +163,7 @@
 			"ctrl-j": "workspace::ActivatePaneDown",
 		},
 	},
-	// Panel nagivation
+	// Panel navigation
 	{
 		"context": "Dock",
 		"bindings": {

--- a/keymap.json
+++ b/keymap.json
@@ -1,226 +1,228 @@
 [
-  {
-    "context": "Editor && (vim_mode == normal || vim_mode == visual) && !VimWaiting && !menu",
-    "bindings": {
-      // put key-bindings here if you want them to work in normal & visual mode
-      // Git
-      "space g h d": "editor::ToggleSelectedDiffHunks",
-      "space g s": "git_panel::ToggleFocus",
-      // Toggle inlay hints
-      "space t i": "editor::ToggleInlayHints",
-      // Toggle soft wrap
-      "space u w": "editor::ToggleSoftWrap",
-      // NOTE: Toggle Zen mode, not fully working yet
-      "space c z": "workspace::ToggleCenteredLayout",
-      // Open markdown preview
-      "space m p": "markdown::OpenPreview",
-      "space m P": "markdown::OpenPreviewToTheSide",
-      // Open recent project
-      "space f p": "projects::OpenRecent",
-      // Search word under cursor
-      "space s w": "pane::DeploySearch",
-      // Search on current buffer
-      "space s b": "buffer_search::Deploy",
-      // Chat with AI
-      "space a c": "agent::ToggleFocus",
-      // Go to file with `gf`
-      "g f": "editor::OpenExcerpts",
-    },
-  },
-  {
-    "context": "Editor && vim_mode == normal && !VimWaiting && !menu",
-    "bindings": {
-      // put key-bindings here if you want them to work only in normal mode
-      // Window movement bindings
-      // Ctrl jklk to move between panes
-      "ctrl-h": "workspace::ActivatePaneLeft",
-      "ctrl-l": "workspace::ActivatePaneRight",
-      "ctrl-k": "workspace::ActivatePaneUp",
-      "ctrl-j": "workspace::ActivatePaneDown",
-      // +LSP
-      "space c a": "editor::ToggleCodeActions",
-      "space .": "editor::ToggleCodeActions",
-      "space c r": "editor::Rename",
-      "g d": "editor::GoToDefinition",
-      "g D": "editor::GoToDefinitionSplit",
-      "g i": "editor::GoToImplementation",
-      "g I": "editor::GoToImplementationSplit",
-      "g t": "editor::GoToTypeDefinition",
-      "g T": "editor::GoToTypeDefinitionSplit",
-      "g r": "editor::FindAllReferences",
-      "] d": "editor::GoToDiagnostic",
-      "[ d": "editor::GoToPreviousDiagnostic",
-      // TODO: Go to next/prev error
-      "] e": "editor::GoToDiagnostic",
-      "[ e": "editor::GoToPreviousDiagnostic",
-      // Symbol search
-      "s s": "outline::Toggle",
-      "s S": "project_symbols::Toggle",
-      // Diagnostic
-      "space x x": "diagnostics::Deploy",
-      // +Git
-      // Git prev/next hunk
-      "] h": "editor::GoToHunk",
-      "[ h": "editor::GoToPreviousHunk",
-      // TODO: git diff is not ready yet, refer https://github.com/zed-industries/zed/issues/8665#issuecomment-2194000497
-      // + Buffers
-      // Switch between buffers
-      "shift-h": "pane::ActivatePreviousItem",
-      "shift-l": "pane::ActivateNextItem",
-      // Close active panel
-      "shift-q": "pane::CloseActiveItem",
-      "ctrl-q": "pane::CloseActiveItem",
-      "space b d": "pane::CloseActiveItem",
-      // Close other items
-      "space b o": "pane::CloseOtherItems",
-      // Save file
-      "ctrl-s": "workspace::Save",
-      // File finder
-      "space space": "file_finder::Toggle",
-      // Project search
-      "space /": "pane::DeploySearch",
-      // TODO: Open other files
-      // Show project panel with current file
-      "space e": "pane::RevealInProjectPanel",
-    },
-  },
-  // Empty pane, set of keybindings that are available when there is no active editor
-  {
-    "context": "EmptyPane || SharedScreen",
-    "bindings": {
-      // Open file finder
-      "space space": "file_finder::Toggle",
-      // Open recent project
-      "space f p": "projects::OpenRecent",
-    },
-  },
-  // Comment code
-  {
-    "context": "Editor && vim_mode == visual && !VimWaiting && !menu",
-    "bindings": {
-      // visual, visual line & visual block modes
-      "g c": "editor::ToggleComments",
-    },
-  },
-  // Better escape
-  {
-    "context": "Editor && vim_mode == insert && !menu",
-    "bindings": {
-      "j j": "vim::NormalBefore", // remap jj in insert mode to escape
-      "j k": "vim::NormalBefore", // remap jk in insert mode to escape
-    },
-  },
-  // Rename
-  {
-    "context": "Editor && vim_operator == c",
-    "bindings": {
-      "c": "vim::CurrentLine",
-      "r": "editor::Rename", // zed specific
-    },
-  },
-  // Code Action
-  {
-    "context": "Editor && vim_operator == c",
-    "bindings": {
-      "c": "vim::CurrentLine",
-      "a": "editor::ToggleCodeActions", // zed specific
-    },
-  },
-  // Toggle terminal
-  {
-    "context": "Workspace",
-    "bindings": {
-      "ctrl-\\": "terminal_panel::ToggleFocus",
-    },
-  },
-  {
-    "context": "Terminal",
-    "bindings": {
-      "ctrl-h": "workspace::ActivatePaneLeft",
-      "ctrl-l": "workspace::ActivatePaneRight",
-      "ctrl-k": "workspace::ActivatePaneUp",
-      "ctrl-j": "workspace::ActivatePaneDown",
-    },
-  },
-  // File panel (netrw)
-  {
-    "context": "ProjectPanel && not_editing",
-    "bindings": {
-      "a": "project_panel::NewFile",
-      "A": "project_panel::NewDirectory",
-      "r": "project_panel::Rename",
-      "d": "project_panel::Delete",
-      "x": "project_panel::Cut",
-      "c": "project_panel::Copy",
-      "p": "project_panel::Paste",
-      // Close project panel as project file panel on the right
-      "q": "workspace::ToggleRightDock",
-      "space e": "workspace::ToggleRightDock",
-      // Navigate between panel
-      "ctrl-h": "workspace::ActivatePaneLeft",
-      "ctrl-l": "workspace::ActivatePaneRight",
-      "ctrl-k": "workspace::ActivatePaneUp",
-      "ctrl-j": "workspace::ActivatePaneDown",
-    },
-  },
-  // Panel nagivation
-  {
-    "context": "Dock",
-    "bindings": {
-      "ctrl-w h": "workspace::ActivatePaneLeft",
-      "ctrl-w l": "workspace::ActivatePaneRight",
-      "ctrl-w k": "workspace::ActivatePaneUp",
-      "ctrl-w j": "workspace::ActivatePaneDown",
-    },
-  },
-  {
-    "context": "Workspace",
-    "bindings": {
-      // Map VSCode like keybindings
-      "cmd-b": "workspace::ToggleRightDock",
-    },
-  },
-  // Run nearest task
-  {
-    "context": "EmptyPane || SharedScreen || vim_mode == normal",
-    "bindings": {
-      "space r t": [
-        "editor::SpawnNearestTask",
-        {
-          "reveal": "no_focus"
-        }
-      ],
-    },
-  },
-  // Sneak motion, refer https://github.com/zed-industries/zed/pull/22793/files#diff-90c0cb07588e2f309c31f0bb17096728b8f4e0bad71f3152d4d81ca867321c68
-  {
-    "context": "vim_mode == normal || vim_mode == visual",
-    "bindings": {
-      "s": [
-        "vim::PushSneak",
-        {}
-      ],
-      "S": [
-        "vim::PushSneakBackward",
-        {}
-      ],
-    },
-  },
-  // Which key, refer to https://github.com/zed-industries/zed/pull/43618
-  {
-    "context": "(VimControl && !menu)",
-    "bindings": {
-      "space": null, // Disable the default action vim::WrappingRight
-    },
-  },
-  // Subword motion is not working really nice with `ciw`, disable for now
-  // {
-  //   "context": "VimControl && !menu",
-  //   "bindings": {
-  //     "w": "vim::NextSubwordStart",
-  //     "b": "vim::PreviousSubwordStart",
-  //     "e": "vim::NextSubwordEnd",
-  //     "g e": "vim::PreviousSubwordEnd"
-  //   }
-  // }
+	{
+		"context": "Editor && (vim_mode == normal || vim_mode == visual) && !VimWaiting && !menu",
+		"bindings": {
+			// put key-bindings here if you want them to work in normal & visual mode
+			// Git
+			"space g h d": "editor::ToggleSelectedDiffHunks",
+			"space g s": "git_panel::ToggleFocus",
+			// Toggle inlay hints
+			"space t i": "editor::ToggleInlayHints",
+			// Toggle soft wrap
+			"space u w": "editor::ToggleSoftWrap",
+			// NOTE: Toggle Zen mode, not fully working yet
+			"space c z": "workspace::ToggleCenteredLayout",
+			// Open markdown preview
+			"space m p": "markdown::OpenPreview",
+			"space m P": "markdown::OpenPreviewToTheSide",
+			// Open recent project
+			"space f p": "projects::OpenRecent",
+			// Search word under cursor
+			"space s w": "pane::DeploySearch",
+			// Search on current buffer
+			"space s b": "buffer_search::Deploy",
+			// Chat with AI
+			"space a c": "agent::ToggleFocus",
+			// Go to file with `gf`
+			"g f": "editor::OpenExcerpts",
+		},
+	},
+	{
+		"context": "Editor && vim_mode == normal && !VimWaiting && !menu",
+		"bindings": {
+			// put key-bindings here if you want them to work only in normal mode
+			// Window movement bindings
+			// Ctrl jklk to move between panes
+			"ctrl-h": "workspace::ActivatePaneLeft",
+			"ctrl-l": "workspace::ActivatePaneRight",
+			"ctrl-k": "workspace::ActivatePaneUp",
+			"ctrl-j": "workspace::ActivatePaneDown",
+			// +LSP
+			"space c a": "editor::ToggleCodeActions",
+			"space .": "editor::ToggleCodeActions",
+			"space c r": "editor::Rename",
+			"g d": "editor::GoToDefinition",
+			"g D": "editor::GoToDefinitionSplit",
+			"g i": "editor::GoToImplementation",
+			"g I": "editor::GoToImplementationSplit",
+			"g t": "editor::GoToTypeDefinition",
+			"g T": "editor::GoToTypeDefinitionSplit",
+			"g r": "editor::FindAllReferences",
+			"] d": "editor::GoToDiagnostic",
+			"[ d": "editor::GoToPreviousDiagnostic",
+			// TODO: Go to next/prev error
+			"] e": "editor::GoToDiagnostic",
+			"[ e": "editor::GoToPreviousDiagnostic",
+			// Symbol search
+			"s s": "outline::Toggle",
+			"s S": "project_symbols::Toggle",
+			// Diagnostic
+			"space x x": "diagnostics::Deploy",
+			// +Git
+			// Git prev/next hunk
+			"] h": "editor::GoToHunk",
+			"[ h": "editor::GoToPreviousHunk",
+			// TODO: git diff is not ready yet, refer https://github.com/zed-industries/zed/issues/8665#issuecomment-2194000497
+			// + Buffers
+			// Switch between buffers
+			"shift-h": "pane::ActivatePreviousItem",
+			"shift-l": "pane::ActivateNextItem",
+			// Close active panel
+			"shift-q": "pane::CloseActiveItem",
+			"ctrl-q": "pane::CloseActiveItem",
+			"space b d": "pane::CloseActiveItem",
+			// Close other items
+			"space b o": "pane::CloseOtherItems",
+			// Save file
+			"ctrl-s": "workspace::Save",
+			// File finder
+			"space space": "file_finder::Toggle",
+			// Project search
+			"space /": "pane::DeploySearch",
+			// TODO: Open other files
+			// Show project panel with current file
+			"space e": "pane::RevealInProjectPanel",
+		},
+	},
+	// Empty pane, set of keybindings that are available when there is no active editor
+	{
+		"context": "EmptyPane || SharedScreen",
+		"bindings": {
+			// Open file finder
+			"space space": "file_finder::Toggle",
+			// Open recent project
+			"space f p": "projects::OpenRecent",
+		},
+	},
+	// Comment code
+	{
+		"context": "Editor && vim_mode == visual && !VimWaiting && !menu",
+		"bindings": {
+			// visual, visual line & visual block modes
+			"g c": "editor::ToggleComments",
+		},
+	},
+	// Better escape
+	{
+		"context": "Editor && vim_mode == insert && !menu",
+		"bindings": {
+			"j j": "vim::NormalBefore", // remap jj in insert mode to escape
+			"j k": "vim::NormalBefore", // remap jk in insert mode to escape
+		},
+	},
+	// Rename
+	{
+		"context": "Editor && vim_operator == c",
+		"bindings": {
+			"c": "vim::CurrentLine",
+			"r": "editor::Rename", // zed specific
+		},
+	},
+	// Code Action
+	{
+		"context": "Editor && vim_operator == c",
+		"bindings": {
+			"c": "vim::CurrentLine",
+			"a": "editor::ToggleCodeActions", // zed specific
+		},
+	},
+	// Toggle terminal
+	{
+		"context": "Workspace",
+		"bindings": {
+			"ctrl-\\": "terminal_panel::ToggleFocus",
+		},
+	},
+	{
+		"context": "Terminal",
+		"bindings": {
+			"ctrl-h": "workspace::ActivatePaneLeft",
+			"ctrl-l": "workspace::ActivatePaneRight",
+			"ctrl-k": "workspace::ActivatePaneUp",
+			"ctrl-j": "workspace::ActivatePaneDown",
+		},
+	},
+	// File panel (netrw)
+	{
+		"context": "ProjectPanel && not_editing",
+		"bindings": {
+			"a": "project_panel::NewFile",
+			"A": "project_panel::NewDirectory",
+			"r": "project_panel::Rename",
+			"d": "project_panel::Delete",
+			"x": "project_panel::Cut",
+			"c": "project_panel::Copy",
+			"p": "project_panel::Paste",
+			// Close project panel as project file panel on the right
+			"q": "workspace::ToggleRightDock",
+			"space e": "workspace::ToggleRightDock",
+			// Navigate between panel
+			"ctrl-h": "workspace::ActivatePaneLeft",
+			"ctrl-l": "workspace::ActivatePaneRight",
+			"ctrl-k": "workspace::ActivatePaneUp",
+			"ctrl-j": "workspace::ActivatePaneDown",
+		},
+	},
+	// Panel nagivation
+	{
+		"context": "Dock",
+		"bindings": {
+			"ctrl-w h": "workspace::ActivatePaneLeft",
+			"ctrl-w l": "workspace::ActivatePaneRight",
+			"ctrl-w k": "workspace::ActivatePaneUp",
+			"ctrl-w j": "workspace::ActivatePaneDown",
+		},
+	},
+	{
+		"context": "Workspace",
+		"bindings": {
+			// Map VSCode like keybindings
+			"cmd-b": "workspace::ToggleRightDock",
+		},
+	},
+	// Run nearest task
+	{
+		"context": "EmptyPane || SharedScreen || vim_mode == normal",
+		"bindings": {
+			"space r t": [
+				"editor::SpawnNearestTask",
+				{
+					"reveal": "no_focus",
+				},
+			],
+		},
+	},
+	// Sneak motion, refer https://github.com/zed-industries/zed/pull/22793/files#diff-90c0cb07588e2f309c31f0bb17096728b8f4e0bad71f3152d4d81ca867321c68
+	{
+		"context": "vim_mode == normal || vim_mode == visual",
+		"bindings": {
+			"s": ["vim::PushSneak", {}],
+			"S": ["vim::PushSneakBackward", {}],
+		},
+	},
+	// Which key, refer to https://github.com/zed-industries/zed/pull/43618
+	{
+		"context": "(VimControl && !menu)",
+		"bindings": {
+			"space": null, // Disable the default action vim::WrappingRight
+		},
+	},
+	// FFF GUI, refer https://github.com/th0jensen/fff-gpui#configuration
+	{
+		"context": "Workspace",
+		"bindings": {
+			"space f f": ["task::Spawn", { "task_name": "fff-gpui: Files" }],
+			"space f g": ["task::Spawn", { "task_name": "fff-gpui: Grep" }],
+		},
+	},
+	// Subword motion is not working really nice with `ciw`, disable for now
+	// {
+	//   "context": "VimControl && !menu",
+	//   "bindings": {
+	//     "w": "vim::NextSubwordStart",
+	//     "b": "vim::PreviousSubwordStart",
+	//     "e": "vim::NextSubwordEnd",
+	//     "g e": "vim::PreviousSubwordEnd"
+	//   }
+	// }
 ]

--- a/settings.json
+++ b/settings.json
@@ -8,14 +8,14 @@
 // from the command palette or from `Zed` application menu.
 {
 	"colorize_brackets": true,
- "code_lens": "on",
- "toolbar": {
-  "code_actions": true
- },
- "show_signature_help_after_edits": true,
- "auto_signature_help": true,
- "redact_private_values": true,
- "cli_default_open_behavior": "existing_window",
+	"code_lens": "on",
+	"toolbar": {
+		"code_actions": true,
+	},
+	"show_signature_help_after_edits": true,
+	"auto_signature_help": true,
+	"redact_private_values": true,
+	"cli_default_open_behavior": "existing_window",
 	"edit_predictions": {
 		"provider": "zed",
 	},
@@ -76,7 +76,6 @@
 	"use_system_window_tabs": true,
 	"buffer_font_fallbacks": [
 		"Maple Mono NF",
-		"OperatorMonoLig Nerd Font",
 		"JetBrainsMono Nerd Font Mono",
 		"Menlo",
 		"Monaco",
@@ -113,7 +112,7 @@
 	"vim": {},
 	"which_key": {
 		"delay_ms": 500,
-  "enabled": true,
+		"enabled": true,
 	},
 	// use relative line numbers
 	"relative_line_numbers": "enabled",
@@ -140,39 +139,39 @@
 	// Use Copilot Chat AI as default
 	"agent": {
 		"default_profile": "write",
-  "favorite_models": [
-   {
-    "provider": "opencode",
-    "model": "go/minimax-m2.7",
-    "enable_thinking": false
-   },
-   {
-    "provider": "opencode",
-    "model": "go/glm-5.1",
-    "enable_thinking": false
-   },
-   {
-    "provider": "CrofAI",
-    "model": "kimi-k2.6",
-    "enable_thinking": false
-   },
-   {
-    "provider": "CrofAI",
-    "model": "glm-5.1",
-    "enable_thinking": false
-   },
-   {
-    "provider": "CrofAI",
-    "model": "deepseek-v4-pro",
-    "enable_thinking": false
-   },
-   {
-    "provider": "opencode",
-    "model": "go/kimi-k2.6",
-    "enable_thinking": false
-   }
-  ],
-  "dock": "left",
+		"favorite_models": [
+			{
+				"provider": "opencode",
+				"model": "go/minimax-m2.7",
+				"enable_thinking": false,
+			},
+			{
+				"provider": "opencode",
+				"model": "go/glm-5.1",
+				"enable_thinking": false,
+			},
+			{
+				"provider": "CrofAI",
+				"model": "kimi-k2.6",
+				"enable_thinking": false,
+			},
+			{
+				"provider": "CrofAI",
+				"model": "glm-5.1",
+				"enable_thinking": false,
+			},
+			{
+				"provider": "CrofAI",
+				"model": "deepseek-v4-pro",
+				"enable_thinking": false,
+			},
+			{
+				"provider": "opencode",
+				"model": "go/kimi-k2.6",
+				"enable_thinking": false,
+			},
+		],
+		"dock": "left",
 		"inline_assistant_model": {
 			"provider": "ollama",
 			"model": "gpt-oss:120b-cloud",
@@ -374,10 +373,6 @@
 	},
 	"collaboration_panel": {
 		"dock": "right",
-	},
-	// Move some unnecessary panels to the left
-	"notification_panel": {
-		"dock": "left",
 	},
 	"context_servers": {
 		"react-grab-mcp": {

--- a/tasks.json
+++ b/tasks.json
@@ -1,8 +1,7 @@
 [
 	{
 		"label": "fff-gpui: Files",
-		"command": "fff-gpui --open .",
-		"env": { "EDITOR": "zed" },
+		"command": "EDITOR=zed fff-gpui --open .",
 		"use_new_terminal": false,
 		"allow_concurrent_runs": false,
 		"reveal": "never",
@@ -15,8 +14,7 @@
 	},
 	{
 		"label": "fff-gpui: Grep",
-		"command": "fff-gpui --open . --grep",
-		"env": { "EDITOR": "zed" },
+		"command": "EDITOR=zed fff-gpui --open . --grep",
 		"use_new_terminal": false,
 		"allow_concurrent_runs": false,
 		"reveal": "never",

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,30 @@
+[
+	{
+		"label": "fff-gpui: Files",
+		"command": "fff-gpui --open .",
+		"env": { "EDITOR": "zed" },
+		"use_new_terminal": false,
+		"allow_concurrent_runs": false,
+		"reveal": "never",
+		"reveal_target": "dock",
+		"hide": "always",
+		"shell": "system",
+		"show_summary": false,
+		"show_command": false,
+		"save": "none"
+	},
+	{
+		"label": "fff-gpui: Grep",
+		"command": "fff-gpui --open . --grep",
+		"env": { "EDITOR": "zed" },
+		"use_new_terminal": false,
+		"allow_concurrent_runs": false,
+		"reveal": "never",
+		"reveal_target": "dock",
+		"hide": "always",
+		"shell": "system",
+		"show_summary": false,
+		"show_command": false,
+		"save": "none"
+	}
+]


### PR DESCRIPTION
## What

- Added **FFF GUI** keybindings (`space f f` → Files, `space f g` → Grep) for a fast fuzzy file finder and grep UI
- Added **tasks.json** backup with FFF GUI task definitions for `cli.sh` to copy from Zed config
- Removed `OperatorMonoLig Nerd Font` from buffer font fallbacks (no longer used)
- Removed `notification_panel` left dock config (unnecessary clutter)
- Normalized indentation in `keymap.json` and `settings.json` from mixed tabs/spaces to consistent tabs
- Documented Tasks section in README with auto-generated content via `cli.ts`

## Why

- FFF GUI (https://github.com/th0jensen/fff-gpui) provides a much faster file finding and grep experience directly in Zed
- `tasks.json` is needed as a backup (same pattern as `settings.json` / `keymap.json`) — `cli.sh` now copies all three from `~/.config/zed/`
- OperatorMonoLig font is not installed/used anymore
- Notification panel on the left doesn't add value — cleaner to keep default
- Inconsistent indentation made diffs noisy and harder to maintain

## How

| File | Change |
|------|--------|
| `keymap.json` | Added `space f f` / `space f g` bindings; converted to tab indentation |
| `settings.json` | Removed `OperatorMonoLig`, `notification_panel` left dock; fixed indentation |
| `tasks.json` | New file — FFF GUI task definitions (`fff-gpui: Files`, `fff-gpui: Grep`) |
| `cli.sh` | Added `cp ~/.config/zed/tasks.json tasks.json` step |
| `cli.ts` | Added tasks.json reading and `<!-- ALL-TASKS:START/END -->` generation |
| `README.md` | Synced generated timestamp; documented new Tasks section with FFF GUI markers |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README expanded with FFF GUI install, keybindings, Tasks section and refreshed configuration examples

* **New Features**
  * Added FFF GUI tasks (Files, Grep) and keybindings (space f f / space f g)
  * Added editor keybinding `g f`

* **Updates**
  * Adjusted font fallbacks and panel docking; reformatted config examples

* **Chores**
  * CLI now conditionally copies tasks.json when present and reports status

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jellydn/zed-101-setup/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->